### PR TITLE
[FEATURE] [NVS-75] 영상 메타 데이터 전송

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,209 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,python
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,python
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,python

--- a/client/client.py
+++ b/client/client.py
@@ -1,0 +1,59 @@
+import subprocess
+import uuid
+import sys
+from datetime import datetime
+
+# --- 설정 ---
+SERVER_IP = '127.0.0.1'
+SERVER_PORT = 8890  # MediaMTX에 설정한 SRT 포트
+
+# --- 동적 streamid 생성 ---
+# 1. 클라이언트를 식별하기 위한 고유 ID를 생성합니다.
+CLIENT_UUID = str(uuid.uuid4())
+# 2. 현재 시간을 "YYYYMMDD-HHMMSS" 형식의 문자열로 변환합니다.
+REQUEST_TIME = datetime.now().strftime("%Y%m%d-%H%M%S")
+
+# 3. 'publish:uuid/timestamp' 형식에 맞게 SRT URL을 생성합니다.
+SRT_URL = f'srt://{SERVER_IP}:{SERVER_PORT}?streamid=publish:{CLIENT_UUID}/{REQUEST_TIME}'
+
+
+# --- FFmpeg 명령어 생성 ---
+# 사용자가 요청한 새로운 명령어 형식에 맞게 재구성합니다.
+# macOS (avfoundation) 기준입니다.
+command = [
+    'ffmpeg',
+    '-f', 'avfoundation',
+    '-framerate', '30',
+    '-pix_fmt', 'nv12',  # 입력 픽셀 포맷
+    '-i', '0',           # 입력 장치 (0번 비디오)
+    '-c:v', 'libx264',
+    '-preset', 'veryfast',
+    '-tune', 'zerolatency',
+    '-f', 'mpegts',      # SRT 전송을 위한 컨테이너 포맷
+    SRT_URL
+]
+
+print("-" * 40)
+print(f"클라이언트 UUID: {CLIENT_UUID}")
+print(f"요청 시간: {REQUEST_TIME}")
+print(f"MediaMTX 서버로 영상 전송을 시작합니다.")
+print(f"  ==> {SRT_URL}")
+print("실행될 FFmpeg 명령어:")
+print(' '.join(command))
+print("-" * 40)
+
+try:
+    # FFmpeg 프로세스를 실행합니다.
+    process = subprocess.Popen(command)
+    process.wait()
+except FileNotFoundError:
+    print("오류: ffmpeg이 설치되어 있지 않거나 PATH에 등록되지 않았습니다.")
+    sys.exit()
+except KeyboardInterrupt:
+    print("\n사용자에 의해 전송이 중단되었습니다.")
+    process.terminate()
+finally:
+    # 프로세스가 여전히 실행 중이면 강제 종료합니다.
+    if 'process' in locals() and process.poll() is None:
+        process.kill()
+    print("프로그램을 종료합니다.")

--- a/client/client.py
+++ b/client/client.py
@@ -24,12 +24,14 @@ command = [
     'ffmpeg',
     '-f', 'avfoundation',
     '-framerate', '30',
-    '-pix_fmt', 'nv12',  # 입력 픽셀 포맷
-    '-i', '0',           # 입력 장치 (0번 비디오)
+    '-pix_fmt', 'nv12',
+    '-i', '0:0',           # ⬅️ 비디오 + 오디오
     '-c:v', 'libx264',
     '-preset', 'veryfast',
     '-tune', 'zerolatency',
-    '-f', 'mpegts',      # SRT 전송을 위한 컨테이너 포맷
+    '-c:a', 'aac',         # ⬅️ 오디오 코덱
+    '-b:a', '128k',        # ⬅️ 오디오 비트레이트
+    '-f', 'mpegts',
     SRT_URL
 ]
 

--- a/client/client.py
+++ b/client/client.py
@@ -2,38 +2,62 @@ import subprocess
 import uuid
 import sys
 from datetime import datetime
+import platform  # ⬅️ 운영체제 확인을 위해 추가
 
 # --- 설정 ---
 SERVER_IP = '127.0.0.1'
 SERVER_PORT = 8890  # MediaMTX에 설정한 SRT 포트
 
 # --- 동적 streamid 생성 ---
-# 1. 클라이언트를 식별하기 위한 고유 ID를 생성합니다.
 CLIENT_UUID = str(uuid.uuid4())
-# 2. 현재 시간을 "YYYYMMDD-HHMMSS" 형식의 문자열로 변환합니다.
 REQUEST_TIME = datetime.now().strftime("%Y%m%d-%H%M%S")
-
-# 3. 'publish:uuid/timestamp' 형식에 맞게 SRT URL을 생성합니다.
 SRT_URL = f'srt://{SERVER_IP}:{SERVER_PORT}?streamid=publish:{CLIENT_UUID}/{REQUEST_TIME}'
 
+# --- 운영체제에 따라 FFmpeg 명령어 분기 ---
+command = []
+current_os = platform.system()
 
-# --- FFmpeg 명령어 생성 ---
-# 사용자가 요청한 새로운 명령어 형식에 맞게 재구성합니다.
-# macOS (avfoundation) 기준입니다.
-command = [
-    'ffmpeg',
-    '-f', 'avfoundation',
-    '-framerate', '30',
-    '-pix_fmt', 'nv12',
-    '-i', '0:0',           # ⬅️ 비디오 + 오디오
-    '-c:v', 'libx264',
-    '-preset', 'veryfast',
-    '-tune', 'zerolatency',
-    '-c:a', 'aac',         # ⬅️ 오디오 코덱
-    '-b:a', '128k',        # ⬅️ 오디오 비트레이트
-    '-f', 'mpegts',
-    SRT_URL
-]
+if current_os == "Darwin":  # 🍎 "Darwin"은 macOS의 커널 이름입니다.
+    print(">>> macOS 환경을 감지했습니다.")
+    command = [
+        'ffmpeg',
+        '-f', 'avfoundation',
+        '-framerate', '30',
+        '-pix_fmt', 'nv12',
+        '-i', '0:0',           # macOS: 비디오장치 0번, 오디오장치 0번
+        '-c:v', 'libx264',
+        '-preset', 'veryfast',
+        '-tune', 'zerolatency',
+        '-c:a', 'aac',
+        '-b:a', '128k',
+        '-f', 'mpegts',
+        SRT_URL
+    ]
+elif current_os == "Linux":  # 🐧 "Linux"는 Ubuntu를 포함한 리눅스 계열입니다.
+    print(">>> Linux 환경(Ubuntu)을 감지했습니다.")
+    command = [
+        'ffmpeg',
+        # 비디오 입력 (웹캠)
+        '-f', 'v4l2',
+        '-framerate', '30',
+        '-video_size', '1280x720',
+        '-i', '/dev/video0',      # Linux: 첫 번째 웹캠
+        # 오디오 입력 (마이크)
+        '-f', 'alsa',
+        '-i', 'hw:0',             # Linux: 첫 번째 사운드카드
+        # 출력 및 인코딩 설정
+        '-c:v', 'libx264',
+        '-preset', 'veryfast',
+        '-tune', 'zerolatency',
+        '-c:a', 'aac',
+        '-b:a', '128k',
+        '-f', 'mpegts',
+        SRT_URL
+    ]
+else:
+    print(f"오류: 지원되지 않는 운영체제({current_os})입니다. macOS 또는 Linux에서 실행해주세요.")
+    sys.exit()
+
 
 print("-" * 40)
 print(f"클라이언트 UUID: {CLIENT_UUID}")
@@ -45,7 +69,6 @@ print(' '.join(command))
 print("-" * 40)
 
 try:
-    # FFmpeg 프로세스를 실행합니다.
     process = subprocess.Popen(command)
     process.wait()
 except FileNotFoundError:
@@ -55,7 +78,6 @@ except KeyboardInterrupt:
     print("\n사용자에 의해 전송이 중단되었습니다.")
     process.terminate()
 finally:
-    # 프로세스가 여전히 실행 중이면 강제 종료합니다.
     if 'process' in locals() and process.poll() is None:
         process.kill()
     print("프로그램을 종료합니다.")

--- a/client/setting.md
+++ b/client/setting.md
@@ -29,3 +29,15 @@ sudo apt install ffmpeg
 ffmpeg -version
 ```
 
+&nbsp;
+
+#### 클라이언트 카메라, 마이크 설정
+
+``` bash
+ffmpeg -f avfoundation -list_devices true -i ""
+```
+
+<center><img src="https://image.minnnning.kr/images/023c0443-db6f-47e7-985e-e332c77d02ed.webp" style="zoom:50%;"></center>
+
+클라이언트 28번 줄 카메라 : 마이크 번호 설정을 할 수 있다
+

--- a/client/setting.md
+++ b/client/setting.md
@@ -1,0 +1,31 @@
+## 클라이언트 실행전 ffmpeg설치 필요
+
+#### 맥 (brew 사용):
+
+Homebrew 설치가 완료되면 다음 명령어로 FFmpeg을 설치합니다.
+
+``` bash
+brew install ffmpeg
+```
+
+&nbsp;
+
+#### Ubuntu / Debian (APT 사용)
+
+대부분의 데스크탑 리눅스 사용자가 이용하는 Ubuntu나 Debian 계열에서는 `apt` 명령어를 사용합니다.
+
+```bash
+sudo apt update
+sudo apt install ffmpeg
+```
+
+&nbsp;
+
+### 설치 확인
+
+설치가 완료된 후, 터미널에 다음 명령어를 입력하여 버전 정보가 나오면 정상적으로 설치된 것입니다.
+
+```bash
+ffmpeg -version
+```
+

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  mediamtx:
+    image: bluenviron/mediamtx:latest
+    container_name: mediamtx
+    restart: unless-stopped
+    ports:
+      - "8890:8890/udp"   # SRT 입력
+      - "8888:8888"       # HLS, WebRTC 등
+      - "1935:1935"       # RTMP
+    volumes:
+      - ./mediamtx.yml:/mediamtx.yml:ro
+      - ./recordings:/recordings   # 녹화 저장 경로

--- a/server/mediamtx.yml
+++ b/server/mediamtx.yml
@@ -1,0 +1,56 @@
+# # SRT 리스너를 활성화합니다.
+# srt: yes
+# srtAddress: :8890
+
+# # pathDefaults는 비워둡니다.
+# pathDefaults:
+
+# # paths에 정규표현식을 사용하여 '모든 경로'에 대한 규칙을 명시적으로 정의합니다.
+# paths:
+#   # '~^.*$'는 모든 경로 이름과 일치하는 정규표현식입니다.
+#   '~^.*$':
+#     # 외부 클라이언트(FFmpeg 등)로부터 스트림을 받을 수 있도록 설정합니다.
+#     source: publisher
+
+#     # 이 경로로 들어오는 모든 스트림의 녹화를 활성화합니다.
+#     record: yes
+    
+#     # 녹화 파일 경로입니다. %path 변수가 동적으로 들어온 스트림 이름으로 자동 변경됩니다.
+#     recordPath: ./recordings/%path/%Y-%m-%d_%H-%M-%S-%f
+    
+#     # 녹화 파일 포맷을 fmp4로 지정합니다.
+#     recordFormat: fmp4
+    
+#     # 1분 단위로 파일을 분할합니다.
+#     recordPartDuration: 1m
+    
+#     # 1일이 지난 녹화 파일을 자동으로 삭제합니다.
+#     recordDeleteAfter: 24h
+
+# ffmpeg -f avfoundation -framerate 30 -pix_fmt nv12 -i "0" \
+# -c:v libx264 -preset veryfast -tune zerolatency \
+# -f mpegts "srt://127.0.0.1:8890?streamid=publish:all/asdfasdf"
+
+# SRT 리스너를 활성화합니다.
+srt: yes
+srtAddress: :8890
+
+# pathDefaults는 비워둡니다.
+pathDefaults:
+
+# paths에 정규표현식을 사용하여 '모든 경로'에 대한 규칙을 명시적으로 정의합니다.
+paths:
+  # '~^.*$'는 모든 경로 이름과 일치하는 정규표현식입니다.
+  '~^.*$':
+    source: publisher
+    record: yes
+    recordPath: ./recordings/%path/%Y-%m-%d_%H-%M-%S-%f
+    recordFormat: fmp4
+    
+    # 이 값은 1초로 두는 것을 권장합니다 (갑작스러운 종료 시 최대 1초 분량만 유실).
+    recordPartDuration: 1s
+    
+    # ⬇️ 이 값을 1m으로 수정하여 1분마다 새 파일을 생성하도록 합니다. ⬇️
+    recordSegmentDuration: 1m
+    
+    recordDeleteAfter: 24h

--- a/server/mediamtx.yml
+++ b/server/mediamtx.yml
@@ -1,36 +1,3 @@
-# # SRT 리스너를 활성화합니다.
-# srt: yes
-# srtAddress: :8890
-
-# # pathDefaults는 비워둡니다.
-# pathDefaults:
-
-# # paths에 정규표현식을 사용하여 '모든 경로'에 대한 규칙을 명시적으로 정의합니다.
-# paths:
-#   # '~^.*$'는 모든 경로 이름과 일치하는 정규표현식입니다.
-#   '~^.*$':
-#     # 외부 클라이언트(FFmpeg 등)로부터 스트림을 받을 수 있도록 설정합니다.
-#     source: publisher
-
-#     # 이 경로로 들어오는 모든 스트림의 녹화를 활성화합니다.
-#     record: yes
-    
-#     # 녹화 파일 경로입니다. %path 변수가 동적으로 들어온 스트림 이름으로 자동 변경됩니다.
-#     recordPath: ./recordings/%path/%Y-%m-%d_%H-%M-%S-%f
-    
-#     # 녹화 파일 포맷을 fmp4로 지정합니다.
-#     recordFormat: fmp4
-    
-#     # 1분 단위로 파일을 분할합니다.
-#     recordPartDuration: 1m
-    
-#     # 1일이 지난 녹화 파일을 자동으로 삭제합니다.
-#     recordDeleteAfter: 24h
-
-# ffmpeg -f avfoundation -framerate 30 -pix_fmt nv12 -i "0" \
-# -c:v libx264 -preset veryfast -tune zerolatency \
-# -f mpegts "srt://127.0.0.1:8890?streamid=publish:all/asdfasdf"
-
 # SRT 리스너를 활성화합니다.
 srt: yes
 srtAddress: :8890
@@ -50,7 +17,7 @@ paths:
     # 이 값은 1초로 두는 것을 권장합니다 (갑작스러운 종료 시 최대 1초 분량만 유실).
     recordPartDuration: 1s
     
-    # ⬇️ 이 값을 1m으로 수정하여 1분마다 새 파일을 생성하도록 합니다. ⬇️
-    recordSegmentDuration: 1m
+    # ⬇️ 이 값을 30s으로 수정하여 30초마다 새 파일을 생성하도록 합니다. ⬇️
+    recordSegmentDuration: 30s
     
     recordDeleteAfter: 24h


### PR DESCRIPTION
## #️⃣ Issue Number

- #1 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
이제는 다중 클라이언트가 영상을 한서버로 보내도 서버는 클라이언트를 구분해서 영상을 저장할 수 있습니다

- 클라이언트는 srt 프로토콜을 이용해서 서버에 영상을 전송합니다
- 서버는 mediaMTX를 사용해서 다중 클라이언트를 구분합니다
- 영상은 uuid/촬영시작날짜시간/촬영날짜시간.mp4 형식으로 저장합니다 지금은 테스트 용도로 영상길이가 30~36s 입니다


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 영상 저장형식을 uuid/촬영시작날짜시간/촬영날짜시간.mp4 이렇게 설정했는데 어떻게 변경해야 상태서버에서 잘 확인할 수 있을까?
- 클라이언트는 어떻게 온오프라인을 구분하고 로컬에 저장할지 ...
- 지금은 클라이언트가 mac 기준인데 나중에 우분투용으로 변경해야한다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)