### PR TITLE
[FEATURE] [NVS-90] 클라이언트 온오프라인시 영상 저장 및 실시간 송출

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -2,82 +2,82 @@ import subprocess
 import uuid
 import sys
 from datetime import datetime
-import platform  # ⬅️ 운영체제 확인을 위해 추가
+import platform
+import socket
+import time
 
 # --- 설정 ---
 SERVER_IP = '127.0.0.1'
-SERVER_PORT = 8890  # MediaMTX에 설정한 SRT 포트
-
-# --- 동적 streamid 생성 ---
+SERVER_PORT = 8890
+SERVER_CHECK_PORT = 9997
 CLIENT_UUID = str(uuid.uuid4())
-REQUEST_TIME = datetime.now().strftime("%Y%m%d-%H%M%S")
-SRT_URL = f'srt://{SERVER_IP}:{SERVER_PORT}?streamid=publish:{CLIENT_UUID}/{REQUEST_TIME}'
 
-# --- 운영체제에 따라 FFmpeg 명령어 분기 ---
-command = []
-current_os = platform.system()
+def check_server_connection(ip, port):
+    """서버의 TCP 포트가 열려 있는지 확인합니다."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(2)
+        if sock.connect_ex((ip, port)) == 0:
+            print(f"✅ 서버 연결 확인: {ip}:{port} 포트가 열려 있습니다.")
+            return True
+        else:
+            print(f"❌ 서버 연결 실패: {ip}:{port} 포트가 닫혀 있거나 응답이 없습니다.")
+            return False
 
-if current_os == "Darwin":  # 🍎 "Darwin"은 macOS의 커널 이름입니다.
-    print(">>> macOS 환경을 감지했습니다.")
-    command = [
-        'ffmpeg',
-        '-f', 'avfoundation',
-        '-framerate', '30',
-        '-pix_fmt', 'nv12',
-        '-i', '0:0',           # macOS: 비디오장치 0번, 오디오장치 0번
-        '-c:v', 'libx264',
-        '-preset', 'veryfast',
-        '-tune', 'zerolatency',
-        '-c:a', 'aac',
-        '-b:a', '128k',
-        '-f', 'mpegts',
-        SRT_URL
-    ]
-elif current_os == "Linux":  # 🐧 "Linux"는 Ubuntu를 포함한 리눅스 계열입니다.
-    print(">>> Linux 환경(Ubuntu)을 감지했습니다.")
-    command = [
-        'ffmpeg',
-        # 비디오 입력 (웹캠)
-        '-f', 'v4l2',
-        '-framerate', '30',
-        '-video_size', '1280x720',
-        '-i', '/dev/video0',      # Linux: 첫 번째 웹캠
-        # 오디오 입력 (마이크)
-        '-f', 'alsa',
-        '-i', 'hw:0',             # Linux: 첫 번째 사운드카드
-        # 출력 및 인코딩 설정
-        '-c:v', 'libx264',
-        '-preset', 'veryfast',
-        '-tune', 'zerolatency',
-        '-c:a', 'aac',
-        '-b:a', '128k',
-        '-f', 'mpegts',
-        SRT_URL
-    ]
-else:
-    print(f"오류: 지원되지 않는 운영체제({current_os})입니다. macOS 또는 Linux에서 실행해주세요.")
-    sys.exit()
+def run_ffmpeg_stream():
+    """FFmpeg 스트리밍 프로세스를 실행하고 끝날 때까지 기다립니다."""
+    REQUEST_TIME = datetime.now().strftime("%Y%m%d-%H%M%S")
+    SRT_URL = f'srt://{SERVER_IP}:{SERVER_PORT}?streamid=publish:{CLIENT_UUID}/{REQUEST_TIME}'
+    
+    command = []
+    current_os = platform.system()
+    if current_os == "Darwin":
+        command = [
+            'ffmpeg', '-f', 'avfoundation', '-framerate', '30', '-pix_fmt', 'nv12',
+            '-i', '0:0', '-c:v', 'libx264', '-preset', 'veryfast', '-tune', 'zerolatency',
+            '-c:a', 'aac', '-b:a', '128k', '-f', 'mpegts', SRT_URL
+        ]
+    elif current_os == "Linux":
+        command = [
+            'ffmpeg', '-f', 'v4l2', '-framerate', '30', '-video_size', '1280x720',
+            '-i', '/dev/video0', '-f', 'alsa', '-i', 'hw:0', '-c:v', 'libx264',
+            '-preset', 'veryfast', '-tune', 'zerolatency', '-c:a', 'aac',
+            '-b:a', '128k', '-f', 'mpegts', SRT_URL
+        ]
+    else:
+        print(f"오류: 지원되지 않는 운영체제({current_os})입니다.")
+        return
 
+    print("-" * 40)
+    print(f"클라이언트 UUID: {CLIENT_UUID}")
+    print(f"MediaMTX 서버로 영상 전송을 시작합니다: {SRT_URL}")
+    print("실행될 FFmpeg 명령어: ", ' '.join(command))
+    print("-" * 40)
+    
+    # ⬇️이 함수는 FFmpeg이 끝날 때까지 자동으로 기다립니다.
+    subprocess.run(command, stderr=sys.stderr, text=True)
 
-print("-" * 40)
-print(f"클라이언트 UUID: {CLIENT_UUID}")
-print(f"요청 시간: {REQUEST_TIME}")
-print(f"MediaMTX 서버로 영상 전송을 시작합니다.")
-print(f"  ==> {SRT_URL}")
-print("실행될 FFmpeg 명령어:")
-print(' '.join(command))
-print("-" * 40)
+# --- 메인 실행 루프 ---
+if __name__ == "__main__":
+    try:
+        while True:
+            # 1. 서버 헬스 체크 포트 확인
+            if check_server_connection(SERVER_IP, SERVER_CHECK_PORT):
+                print("🚀 서버 연결이 확인되었습니다. FFmpeg 스트리밍을 시작합니다.")
+                
+                # ⬇️ 이제 함수 호출 한 줄로 '실행과 기다림'이 모두 끝납니다.
+                run_ffmpeg_stream()
+                
+                print("📡 FFmpeg 프로세스가 종료되었습니다. 잠시 후 재연결을 시도합니다.")
+            
+            # 2. 서버 연결 실패 또는 FFmpeg 종료 시 10초 대기
+            print("10초 후 재연결을 시도합니다...")
+            time.sleep(10)
 
-try:
-    process = subprocess.Popen(command)
-    process.wait()
-except FileNotFoundError:
-    print("오류: ffmpeg이 설치되어 있지 않거나 PATH에 등록되지 않았습니다.")
-    sys.exit()
-except KeyboardInterrupt:
-    print("\n사용자에 의해 전송이 중단되었습니다.")
-    process.terminate()
-finally:
-    if 'process' in locals() and process.poll() is None:
-        process.kill()
-    print("프로그램을 종료합니다.")
+    except KeyboardInterrupt:
+        print("\n사용자에 의해 프로그램이 중단되었습니다.")
+        # run을 사용하면 별도의 프로세스 종료 코드가 필요 없습니다.
+        # 함수가 끝나면 프로세스도 끝나기 때문입니다.
+    except Exception as e:
+        print(f"예상치 못한 오류 발생: {e}")
+    finally:
+        print("프로그램을 종료합니다.")

--- a/client/client.py
+++ b/client/client.py
@@ -5,78 +5,100 @@ from datetime import datetime
 import platform
 import socket
 import time
+import os
 
 # --- 설정 ---
 SERVER_IP = '127.0.0.1'
 SERVER_PORT = 8890
 SERVER_CHECK_PORT = 9997
 CLIENT_UUID = str(uuid.uuid4())
+LOCAL_REC_PATH = f'./{CLIENT_UUID}'
+# 오프라인 녹화 시간
+OFFLINE_REC_DURATION = 30 
 
 def check_server_connection(ip, port):
     """서버의 TCP 포트가 열려 있는지 확인합니다."""
+    print(f"📡 {ip}:{port} 서버 연결 상태 확인 중...")
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(2)
         if sock.connect_ex((ip, port)) == 0:
-            print(f"✅ 서버 연결 확인: {ip}:{port} 포트가 열려 있습니다.")
+            print(f"✅ 연결 성공.")
             return True
         else:
-            print(f"❌ 서버 연결 실패: {ip}:{port} 포트가 닫혀 있거나 응답이 없습니다.")
+            print(f"❌ 연결 실패.")
             return False
 
-def run_ffmpeg_stream():
-    """FFmpeg 스트리밍 프로세스를 실행하고 끝날 때까지 기다립니다."""
+def get_base_ffmpeg_command(os_type):
+    """운영체제에 따라 기본 FFmpeg 입력 명령을 반환합니다."""
+    if os_type == "Darwin":
+        return [
+            'ffmpeg', '-f', 'avfoundation', '-framerate', '30', '-pix_fmt', 'nv12',
+            '-i', '0:0'
+        ]
+    elif os_type == "Linux":
+        return [
+            'ffmpeg', '-f', 'v4l2', '-framerate', '30', '-video_size', '1280x720',
+            '-i', '/dev/video0',
+            '-f', 'alsa', '-i', 'hw:0'
+        ]
+    return None
+
+def stream_to_server():
+    """온라인 모드: 서버로 스트리밍을 시작합니다. 연결이 끊기면 함수가 종료됩니다."""
+    print("\n🚀 [온라인 모드] 서버로 스트리밍을 시작합니다.")
     REQUEST_TIME = datetime.now().strftime("%Y%m%d-%H%M%S")
     SRT_URL = f'srt://{SERVER_IP}:{SERVER_PORT}?streamid=publish:{CLIENT_UUID}/{REQUEST_TIME}'
     
-    command = []
-    current_os = platform.system()
-    if current_os == "Darwin":
-        command = [
-            'ffmpeg', '-f', 'avfoundation', '-framerate', '30', '-pix_fmt', 'nv12',
-            '-i', '0:0', '-c:v', 'libx264', '-preset', 'veryfast', '-tune', 'zerolatency',
-            '-c:a', 'aac', '-b:a', '128k', '-f', 'mpegts', SRT_URL
-        ]
-    elif current_os == "Linux":
-        command = [
-            'ffmpeg', '-f', 'v4l2', '-framerate', '30', '-video_size', '1280x720',
-            '-i', '/dev/video0', '-f', 'alsa', '-i', 'hw:0', '-c:v', 'libx264',
-            '-preset', 'veryfast', '-tune', 'zerolatency', '-c:a', 'aac',
-            '-b:a', '128k', '-f', 'mpegts', SRT_URL
-        ]
-    else:
-        print(f"오류: 지원되지 않는 운영체제({current_os})입니다.")
-        return
+    command = get_base_ffmpeg_command(platform.system())
+    if not command: return
 
-    print("-" * 40)
-    print(f"클라이언트 UUID: {CLIENT_UUID}")
-    print(f"MediaMTX 서버로 영상 전송을 시작합니다: {SRT_URL}")
-    print("실행될 FFmpeg 명령어: ", ' '.join(command))
-    print("-" * 40)
+    command.extend([
+        '-c:v', 'libx264', '-preset', 'veryfast', '-tune', 'zerolatency',
+        '-c:a', 'aac', '-b:a', '128k',
+        '-f', 'mpegts', SRT_URL
+    ])
     
-    # ⬇️이 함수는 FFmpeg이 끝날 때까지 자동으로 기다립니다.
-    subprocess.run(command, stderr=sys.stderr, text=True)
+    print("실행될 명령어: ", ' '.join(command))
+    subprocess.run(command, stderr=sys.stderr)
+
+def record_clip_locally(duration):
+    """오프라인 모드: 클립을 로컬에 저장합니다."""
+    print(f"\n [오프라인 모드] {duration}초 로컬 녹화를 시작합니다.")
+    os.makedirs(LOCAL_REC_PATH, exist_ok=True)
+    
+    file_name = datetime.now().strftime("%Y%m%d-%H%M%S") + ".mp4"
+    output_path = os.path.join(LOCAL_REC_PATH, file_name)
+
+    command = get_base_ffmpeg_command(platform.system())
+    if not command: return
+
+    command.extend([
+        '-t', str(duration),
+        '-c:v', 'libx264', '-preset', 'veryfast',
+        '-c:a', 'aac', '-b:a', '128k',
+        output_path
+    ])
+
+    print(f"녹화 파일 경로: {output_path}")
+    print("실행될 명령어: ", ' '.join(command))
+    subprocess.run(command, stderr=sys.stderr)
+    print(f" {duration}초 녹화 완료.")
 
 # --- 메인 실행 루프 ---
 if __name__ == "__main__":
     try:
         while True:
-            # 1. 서버 헬스 체크 포트 확인
             if check_server_connection(SERVER_IP, SERVER_CHECK_PORT):
-                print("🚀 서버 연결이 확인되었습니다. FFmpeg 스트리밍을 시작합니다.")
-                
-                # ⬇️ 이제 함수 호출 한 줄로 '실행과 기다림'이 모두 끝납니다.
-                run_ffmpeg_stream()
-                
-                print("📡 FFmpeg 프로세스가 종료되었습니다. 잠시 후 재연결을 시도합니다.")
+                stream_to_server()
+                print("\n 스트리밍이 중단되었습니다. 연결 상태를 다시 확인합니다...")
+                time.sleep(2)
             
-            # 2. 서버 연결 실패 또는 FFmpeg 종료 시 10초 대기
-            print("10초 후 재연결을 시도합니다...")
-            time.sleep(10)
+            else:
+                # 함수 호출 시 설정된 OFFLINE_REC_DURATION 값을 전달
+                record_clip_locally(OFFLINE_REC_DURATION)
 
     except KeyboardInterrupt:
         print("\n사용자에 의해 프로그램이 중단되었습니다.")
-        # run을 사용하면 별도의 프로세스 종료 코드가 필요 없습니다.
-        # 함수가 끝나면 프로세스도 끝나기 때문입니다.
     except Exception as e:
         print(f"예상치 못한 오류 발생: {e}")
     finally:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     restart: unless-stopped
     ports:
       - "8890:8890/udp"   # SRT 입력
+      - "9997:9997"
 
     volumes:
       - ./mediamtx.yml:/mediamtx.yml:ro

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   mediamtx:
     image: bluenviron/mediamtx:latest
@@ -7,8 +5,7 @@ services:
     restart: unless-stopped
     ports:
       - "8890:8890/udp"   # SRT 입력
-      - "8888:8888"       # HLS, WebRTC 등
-      - "1935:1935"       # RTMP
+
     volumes:
       - ./mediamtx.yml:/mediamtx.yml:ro
       - ./recordings:/recordings   # 녹화 저장 경로

--- a/server/mediamtx.yml
+++ b/server/mediamtx.yml
@@ -2,6 +2,9 @@
 srt: yes
 srtAddress: :8890
 
+api: yes # api 서버 기능을 활성화 서버가 연결되는지 확인하기 위함
+apiAddress: :9997
+
 # pathDefaults는 비워둡니다.
 pathDefaults:
 


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) - #이슈번호 -->
- #3 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
클라이언트와 mediaMTX 서버 설정을 수정함
- 서버가 정상적인지 확인하기 위해서 mediaMTX의 api 서버를 활성화 시킴(기존 srt 포트는 udp라 socket의 conect_ex가 안된다)
- 클라이언트에서 서버와 연결이 끊기면 바로 로컬 저장
- 로컬 저장은 30초 단위(변경가능) 저장후 다시 서버와 연결확인
- 재연결 안됨 -> 다시 30초 로컬 저장
- 재연결 된다면 서버로 실시간 영상을 보낸다

<img width="488" height="362" alt="스크린샷 2025-09-17 12 01 30" src="https://github.com/user-attachments/assets/b878648b-a987-4d92-ae2e-3209c3a5072a" />


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
로컬에 저장된 영상을 서버로 보내는건 서버 생성이후에 해야될것 같다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)