### PR TITLE
[FEATURE] [NVS-156] 오프라인 영상용 서버

### DIFF
--- a/offline_upload_server/Dockerfile
+++ b/offline_upload_server/Dockerfile
@@ -1,0 +1,17 @@
+# Dockerfile
+
+# 1. 베이스 이미지 설정
+FROM python:3.10-slim
+
+# 2. 작업 디렉토리 설정
+WORKDIR /code
+
+# 3. 의존성 파일 복사 및 설치
+COPY ./requirements.txt /code/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+# 4. 애플리케이션 코드 복사
+COPY ./app /code/app
+
+# 5. 서버 실행 명령어
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/offline_upload_server/app/main.py
+++ b/offline_upload_server/app/main.py
@@ -1,0 +1,37 @@
+# upload_server/app/main.py
+
+from fastapi import FastAPI, File, UploadFile, HTTPException
+from pathlib import Path
+import shutil
+
+app = FastAPI(title="Video Upload Server")
+
+# 컨테이너 내부의 마운트된 볼륨 경로
+# 이 경로는 호스트의 server/recordings 와 연결됩니다.
+BASE_SAVE_DIR = Path("/data")
+
+@app.post("/upload/video/{client_uuid}")
+def upload_video(client_uuid: str, video_file: UploadFile = File(...)):
+    try:
+        # 1. 저장할 경로를 /data 기준으로 정의합니다.
+        save_dir = BASE_SAVE_DIR / client_uuid / "offline"
+
+        # 2. 폴더가 존재하지 않으면 생성합니다.
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+        # 3. 파일을 저장할 최종 경로를 설정합니다.
+        file_path = save_dir / video_file.filename
+
+        # 4. 파일을 디스크에 씁니다.
+        with file_path.open("wb") as buffer:
+            shutil.copyfileobj(video_file.file, buffer)
+
+        return {
+            "message": f"Video '{video_file.filename}' uploaded successfully for client '{client_uuid}'.",
+            "saved_path": str(file_path)
+        }
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"An error occurred: {e}")
+    finally:
+        video_file.file.close()

--- a/offline_upload_server/docker-compose.yml
+++ b/offline_upload_server/docker-compose.yml
@@ -1,0 +1,11 @@
+# upload_server/docker-compose.yml
+services:
+  fastapi_uploader:
+    build: .
+    container_name: offline_upload_server
+    ports:
+      - "8001:8000"
+    volumes:
+      # 현재 위치(upload_server)에서 한 단계 상위 폴더(../)의
+      # server/recordings 폴더를 컨테이너의 /data 폴더와 연결
+      - ../server/recordings:/data

--- a/offline_upload_server/requirements.txt
+++ b/offline_upload_server/requirements.txt
@@ -1,0 +1,4 @@
+# requirements.txt
+fastapi
+uvicorn[standard]
+python-multipart

--- a/server/mediamtx.yml
+++ b/server/mediamtx.yml
@@ -17,10 +17,10 @@ paths:
     recordPath: ./recordings/%path/%Y-%m-%d_%H-%M-%S-%f
     recordFormat: fmp4
     
-    # 이 값은 1초로 두는 것을 권장합니다 (갑작스러운 종료 시 최대 1초 분량만 유실).
-    recordPartDuration: 1s
+    # 영상이 생성되는 단위 설정
+    recordPartDuration: 30s
     
-    # ⬇️ 이 값을 30s으로 수정하여 30초마다 새 파일을 생성하도록 합니다. ⬇️
+    # 영상의 길이 단위 30 +- 3초 정도 오차가 존재
     recordSegmentDuration: 30s
     
     recordDeleteAfter: 24h


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) - #이슈번호 -->
- #7

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
오프라인 영상을 올릴 수 있는 서버를 추가했습니다
업로드 api를 통해서 업로드하면 공용 저장소의 본인 uuid 폴더내 offline 폴더 내부에 영상이 저장됩니다
<img width="430" height="552" alt="스크린샷 2025-09-18 14 54 59" src="https://github.com/user-attachments/assets/14d77e25-1543-4fa4-8f7c-cecafac5e201" />


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
영상 업로드 테스트를 위해 curl 사용
``` bash
curl -X POST -F "video_file=@/Users/minnnning/Desktop/video.mp4" http://localhost:8001/upload/video/dd9d5b14-bde1-41c4-bb07-d92c1dfb1527
```
올릴 영상의 경로 + 블랙박스 uuid를 같이 전송하면 해당 블랙박스 폴더 내에 생성 된다 
## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)