### PR TITLE
[FIX] [NVS-237] 영상 실패하는 에러 수정

### DIFF
--- a/db_upload_server/config.py
+++ b/db_upload_server/config.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 # 기본 경로 설정
-BASE_DIR = Path(os.getenv("BASE_DIR", "/recordings"))
+BASE_DIR = Path(os.getenv("BASE_DIR", "/recordings/ready"))
 
 # 상태별 폴더 경로
 PROCESSING_DIR = BASE_DIR / "processing"

--- a/db_upload_server/video_processor.py
+++ b/db_upload_server/video_processor.py
@@ -23,6 +23,7 @@ class VideoProcessor:
         """경로와 파일로부터 메타데이터를 파싱합니다."""
         parts = self.filepath.parts
         base_index = parts.index(config.PROCESSING_DIR.name)
+        logging.info(f"파싱 중: {self.filepath}, base_index: {base_index}")
 
         created_at_utc = datetime.strptime(self.filepath.stem, "%Y%m%d-%H%M%S")
 
@@ -44,6 +45,8 @@ class VideoProcessor:
             "file_size": self.filepath.stat().st_size,
             "duration": duration,
         }
+
+        logging.info(self.parsed_data)
 
     def _generate_new_names(self):
         """파싱된 데이터를 바탕으로 새 이름과 S3 키를 생성합니다."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   mediamtx_server: # 영상 수신 서버
-    image: bluenviron/mediamtx:latest
+    image: bluenviron/mediamtx:latest-ffmpeg
     container_name: mediamtx-server
     restart: unless-stopped
     ports:
-      - "${MEDIAMTX_SRT_PORT:-8890}:8890/udp"   # SRT 입력
+      - "${MEDIAMTX_SRT_PORT:-8890}:8890/udp"
       - "${MEDIAMTX_CHECK_PORT:-9997}:9997"
     volumes:
       - ./server/mediamtx.yml:/mediamtx.yml:ro
@@ -23,20 +23,20 @@ services:
       - ./db_upload_server/.env
     networks: # 네트워크 추가
       - streaming-network
-  
-  offline_upload_server:  # 오프라인 영상 업로드 서버
-    build:
-      context: ./offline_upload_server
-    container_name: offline-upload-server
-    restart: unless-stopped
-    ports:
-      - "${HOST_PORT:-8001}:${CONTAINER_PORT:-8000}"
-    volumes:
-      - ${HOST_SAVE_PATH:-./recordings}:${CONTAINER_DATA_PATH:-/recordings}
 
-    command: uvicorn app.main:app --host 0.0.0.0 --port ${CONTAINER_PORT:-8000}
-    networks: # 네트워크 추가
-      - streaming-network
+#  offline_upload_server:  # 오프라인 영상 업로드 서버
+#    build:
+#      context: ./offline_upload_server
+#    container_name: offline-upload-server
+#    restart: unless-stopped
+#    ports:
+#      - "${HOST_PORT:-8001}:${CONTAINER_PORT:-8000}"
+#    volumes:
+#      - ${HOST_SAVE_PATH:-./recordings}:${CONTAINER_DATA_PATH:-/recordings}
+#
+#    command: uvicorn app.main:app --host 0.0.0.0 --port ${CONTAINER_PORT:-8000}
+#    networks: # 네트워크 추가
+#      - streaming-network
 
   prometheus:
     image: prom/prometheus:latest

--- a/server/mediamtx.yml
+++ b/server/mediamtx.yml
@@ -1,26 +1,22 @@
-# SRT 리스너를 활성화합니다.
 srt: yes
 srtAddress: :8890
-
-api: yes # api 서버 기능을 활성화 서버가 연결되는지 확인하기 위함
+api: yes
 apiAddress: :9997
-
-# pathDefaults는 비워둡니다.
+metrics: yes
+metricsAddress: :9998
 pathDefaults:
 
-# paths에 정규표현식을 사용하여 '모든 경로'에 대한 규칙을 명시적으로 정의합니다.
 paths:
-  # '~^.*$'는 모든 경로 이름과 일치하는 정규표현식입니다.
   '~^.*$':
     source: publisher
     record: yes
-    recordPath: ./recordings/%path/%Y%m%d-%H%M%S
+    recordPath: ./recordings/writing/%path/%Y%m%d-%H%M%S
     recordFormat: fmp4
-    
-    # 영상이 생성되는 단위 설정
     recordPartDuration: 30s
-    
-    # 영상의 길이 단위 30 +- 3초 정도 오차가 존재
     recordSegmentDuration: 30s
-    
     recordDeleteAfter: 24h
+    runOnRecordSegmentComplete: |
+      /bin/sh -c "
+        mkdir -p \"$(dirname \"$(printf %s \"${MTX_SEGMENT_PATH}\" | sed 's#/writing/#/ready/#')\")\" \
+        && mv \"${MTX_SEGMENT_PATH}\" \"$(printf %s \"${MTX_SEGMENT_PATH}\" | sed 's#/writing/#/ready/#')\"
+      "


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- ex) - #이슈번호 -->
- #25 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- `mediamtx`에서 영상 받는 중에는 `/recordings/writing`에 저장, 영상 저장 후 `/recordings/ready`로 이동하도록 변경했습니다.
- `db upload server`가 스캔하는 베이스 경로를 `/recordings/ready`로 변경했습니다.

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 잘 동작하길 기도해주세요.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)